### PR TITLE
Add chart image generation

### DIFF
--- a/src/atlas.cpp
+++ b/src/atlas.cpp
@@ -147,15 +147,16 @@ py::array_t<std::uint8_t> Atlas::getChartImage()
     }
 
     // Generate a color for each chart
-    std::vector<uint8_t[3]>              chartColors(m_atlas->chartCount);
-    std::uniform_int_distribution<short> distribution(50, 255);
-    size_t                               chartIndex = 0U;
+    std::vector<uint8_t[3]>                     chartColors(m_atlas->chartCount);
+    std::uniform_int_distribution<unsigned int> distribution(0, 254); // Original code uses `% 255`, which excludes 255
+    constexpr unsigned int const                mix        = 192U;
+    size_t                                      chartIndex = 0U;
     for (auto& color : chartColors)
     {
         std::default_random_engine engine(chartIndex++);
-        color[0] = static_cast<std::uint8_t>(distribution(engine));
-        color[1] = static_cast<std::uint8_t>(distribution(engine));
-        color[2] = static_cast<std::uint8_t>(distribution(engine));
+        color[0] = static_cast<std::uint8_t>((distribution(engine) + mix) * 0.5f) ;
+        color[1] = static_cast<std::uint8_t>((distribution(engine) + mix) * 0.5f);
+        color[2] = static_cast<std::uint8_t>((distribution(engine) + mix) * 0.5f);
     }
 
     // Fill an image with the chart colors

--- a/src/atlas.cpp
+++ b/src/atlas.cpp
@@ -24,6 +24,7 @@
 
 #include "atlas.hpp"
 
+#include <array>
 #include <random>
 
 #include <pybind11/numpy.h>
@@ -149,7 +150,7 @@ py::array_t<std::uint8_t> Atlas::getChartImage()
     }
 
     // Generate a color for each chart
-    std::vector<uint8_t[3]>                     chartColors(m_atlas->chartCount);
+    std::vector<std::array<uint8_t, 3>>         chartColors(m_atlas->chartCount);
     std::uniform_int_distribution<unsigned int> distribution(0, 254); // Original code uses `% 255`, which excludes 255
     constexpr unsigned int const                mix        = 192U;
     size_t                                      chartIndex = 0U;

--- a/src/atlas.cpp
+++ b/src/atlas.cpp
@@ -141,6 +141,8 @@ MeshResult Atlas::getMesh(std::uint32_t index)
 
 py::array_t<std::uint8_t> Atlas::getChartImage()
 {
+    // Code inspired by xatlas::writeTga
+
     if (!m_atlas->image || m_atlas->width == 0 || m_atlas->height == 0)
     {
         throw std::runtime_error("The atlas does not have an image.");

--- a/src/atlas.cpp
+++ b/src/atlas.cpp
@@ -156,7 +156,7 @@ py::array_t<std::uint8_t> Atlas::getChartImage()
     size_t                                      chartIndex = 0U;
     for (auto& color : chartColors)
     {
-        std::default_random_engine engine(chartIndex++);
+        std::default_random_engine engine(static_cast<unsigned int>(chartIndex++));
         color[0] = static_cast<std::uint8_t>((distribution(engine) + mix) * 0.5f) ;
         color[1] = static_cast<std::uint8_t>((distribution(engine) + mix) * 0.5f);
         color[2] = static_cast<std::uint8_t>((distribution(engine) + mix) * 0.5f);

--- a/src/atlas.hpp
+++ b/src/atlas.hpp
@@ -52,6 +52,8 @@ public:
 
     MeshResult getMesh(std::uint32_t index);
 
+    pybind11::array_t<std::uint8_t> getChartImage();
+
     static void bind(pybind11::module& m);
 
 private:


### PR DESCRIPTION
Inspired by the function `xatlas::writeTga`, this PR adds a `chart_image` member to the `Atlas` class that represents an image with the individually color-coded charts. It can be used for debugging or just serve as nice visualization of the generated charts.

Example:
```python
vertices, faces = ...

pack_options = xatlas.PackOptions()
pack_options.create_image = True # Setting this option is required, otherwise there is no chart image

atlas = xatlas.Atlas()
atlas.add_mesh(vertices, faces)
atlas.generate(pack_options=pack_options)

plot(atlas.chart_image)
```

![chart_image](https://user-images.githubusercontent.com/9449513/122098791-9258ef80-ce11-11eb-89d9-ba6b6821adde.png)
