### PR TITLE
renamed rotate_charts_to_axis

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -62,6 +62,6 @@ void PackOptions::bind(pybind11::module& m)
         .def_readwrite("blockAlign", &xatlas::PackOptions::blockAlign, "Align charts to 4x4 blocks. Also improves packing speed, since there are fewer possible chart locations to consider.")
         .def_readwrite("bruteForce", &xatlas::PackOptions::bruteForce, "Slower, but gives the best result. If false, use random chart placement.")
         .def_readwrite("create_image", &xatlas::PackOptions::createImage, "Create Atlas::image.")
-        .def_readwrite("rotate_charts_to_a-xis", &xatlas::PackOptions::rotateChartsToAxis, "Rotate charts to the axis of their convex hull.")
+        .def_readwrite("rotate_charts_to_axis", &xatlas::PackOptions::rotateChartsToAxis, "Rotate charts to the axis of their convex hull.")
         .def_readwrite("rotate_charts", &xatlas::PackOptions::rotateCharts, "Rotate charts to improve packing.");
 }


### PR DESCRIPTION
python doesn't like names with a dash so ` rotate_charts_to_a-xis` was renamed to ` rotate_charts_to_axis`