### PR TITLE
Build 3.12 Wheels And Update Pyproject

### DIFF
--- a/.github/workflows/install-and-test.yml
+++ b/.github/workflows/install-and-test.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/install-and-test.yml
+++ b/.github/workflows/install-and-test.yml
@@ -16,21 +16,17 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
         
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
   
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip pytest trimesh wheel setuptools
-        
     - name: Build and install
-      run: pip install --verbose .
+      run: pip install --verbose .[test]
       
     - name: Test
       run: pytest tests

--- a/.github/workflows/install-and-test.yml
+++ b/.github/workflows/install-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
         platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           # We don't support Python 2.7
           CIBW_SKIP: cp27-*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -31,11 +31,11 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - name: Install deps
       run: python -m pip install twine build
@@ -57,7 +57,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,11 +1,9 @@
 name: Wheels
 
 on:
-  # Triggers the workflow on manual dispatch or when a release is published
-  workflow_dispatch:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,11 @@
 name: Wheels
 
 on:
-  push:
-    branches:
-      - main
+  # Triggers the workflow on manual dispatch or when a release is published
+  workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
-        env:
-          # We don't support Python 2.7
-          CIBW_SKIP: cp27-*
         with:
           output-dir: wheelhouse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 # Run the package tests on every wheel using `pytest`
 test-command = "pytest {package}/tests"
-before-test = "pip install pytest"
+
+# will install pytest and other packages in the `test` extra
+test-extras = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,5 @@ test-command = "pytest {package}/tests"
 # will install pytest and other packages in the `test` extra
 test-extras = ["test"]
 
+# Skip PyPy on Windows as it doesn't appear to have numpy wheels
+skip = ["pp*-win*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "xatlas"
 requires-python = ">=3.7"
-version = "0.0.8"
+version = "0.0.9"
 authors = [{name = "Markus Worchel", email = "m.worchel@campus.tu-berlin.de"}]
 license = {file = "LICENSE"}
 description = "Python bindings for xatlas"
@@ -33,4 +33,4 @@ test-command = "pytest {package}/tests"
 test-extras = ["test"]
 
 # Skip PyPy on Windows as it doesn't appear to have numpy wheels
-skip = ["pp*-win*"]
+skip = ["pp*-win*", "*musllinux_i686"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ requires = [
     "cmake>=3.12",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+# Run the package tests on every wheel using `pytest`
+test-command = "pytest {package}/tests"
+before-test = "pip install pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,28 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "xatlas"
+requires-python = ">=3.7"
+version = "0.0.8"
+authors = [{name = "Markus Worchel", email = "m.worchel@campus.tu-berlin.de"}]
+license = {file = "LICENSE"}
+description = "Python bindings for xatlas"
+urls = {Homepage = "https://github.com/mworchel/xatlas-python"}
+dependencies = ["numpy"]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[project.optional-dependencies]
+test = ["trimesh",
+        "pytest"]
+
 [tool.cibuildwheel]
 # Run the package tests on every wheel using `pytest`
 test-command = "pytest {package}/tests"
 
 # will install pytest and other packages in the `test` extra
 test-extras = ["test"]
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 # -*- coding: utf-8 -*-
 import os
-from pathlib import Path
 import sys
 import subprocess
 
@@ -62,7 +61,6 @@ class CMakeBuild(build_ext):
                 cmake_args += ["-GNinja"]
 
         else:
-
             # Single config generators are handled "normally"
             single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
 
@@ -100,25 +98,11 @@ class CMakeBuild(build_ext):
         subprocess.check_call(
             ["cmake", "--build", "."] + build_args, cwd=self.build_temp
         )
-        
-long_description = (Path(__file__).parent / "README.md").read_text()
 
-# The information here can also be placed in setup.cfg - better separation of
+
+# The information here can also be placed in pyproject.toml - better separation of
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
-    name="xatlas",
-    version="0.0.8",
-    python_requires=">=3.7",
-    install_requires=["numpy"],
-    extras_require={'test': ["trimesh", "pytest"]},
-    description="Python bindings for xatlas",
-    author="Markus Worchel",
-    author_email="m.worchel@campus.tu-berlin.de",
-    license='MIT',
-    url='https://github.com/mworchel/xatlas-python',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
     ext_modules=[CMakeExtension("xatlas")],
     cmdclass={"build_ext": CMakeBuild},
-    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
     version="0.0.8",
     python_requires=">=3.7",
     install_requires=["numpy"],
+    extras_require={'test': ["trimesh", "pytest"]},
     description="Python bindings for xatlas",
     author="Markus Worchel",
     author_email="m.worchel@campus.tu-berlin.de",

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
     name="xatlas",
     version="0.0.8",
     python_requires=">=3.7",
+    install_requires=["numpy"],
     description="Python bindings for xatlas",
     author="Markus Worchel",
     author_email="m.worchel@campus.tu-berlin.de",

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 setup(
     name="xatlas",
     version="0.0.8",
+    python_requires=">=3.7",
     description="Python bindings for xatlas",
     author="Markus Worchel",
     author_email="m.worchel@campus.tu-berlin.de",

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -1,10 +1,16 @@
+import os
+
 import numpy as np
 import pytest
 import trimesh
 import xatlas
 
+# current working directory
+cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
+
+
 def test_add_mesh():
-    mesh = trimesh.load_mesh("tests/data/00190663.obj")
+    mesh = trimesh.load_mesh(os.path.join(cwd, "data", "00190663.obj"))
 
     atlas = xatlas.Atlas()
 
@@ -40,28 +46,35 @@ def test_add_mesh():
 
     # Normals have wrong shape (first dimension)
     with pytest.raises(ValueError) as e:
-        atlas.add_mesh(mesh.vertices, mesh.faces,  np.random.rand(1, 3))
+        atlas.add_mesh(mesh.vertices, mesh.faces, np.random.rand(1, 3))
     assert "first dimension" in str(e.value)
 
     # UVs have wrong shape (number of dimensions)
     with pytest.raises(ValueError) as e:
-        atlas.add_mesh(mesh.vertices, mesh.faces, mesh.vertex_normals, np.random.rand(1))
+        atlas.add_mesh(
+            mesh.vertices, mesh.faces, mesh.vertex_normals, np.random.rand(1)
+        )
     assert "Nx2" in str(e.value)
 
     # UVs have wrong shape (second dimension)
     with pytest.raises(ValueError) as e:
-        atlas.add_mesh(mesh.vertices, mesh.faces, mesh.vertex_normals, np.random.rand(1, 1))
+        atlas.add_mesh(
+            mesh.vertices, mesh.faces, mesh.vertex_normals, np.random.rand(1, 1)
+        )
     assert "Nx2" in str(e.value)
 
     # UVs have wrong shape (first dimension)
     with pytest.raises(ValueError) as e:
-        atlas.add_mesh(mesh.vertices, mesh.faces, mesh.vertex_normals, np.random.rand(1, 2))
+        atlas.add_mesh(
+            mesh.vertices, mesh.faces, mesh.vertex_normals, np.random.rand(1, 2)
+        )
     assert "first dimension" in str(e.value)
 
     # Index array references out-of-bounds vertices
     with pytest.raises(RuntimeError) as e:
         atlas.add_mesh(np.random.rand(1, 3), mesh.faces)
     assert "out of range" in str(e.value)
+
 
 def test_generate():
     mesh = trimesh.load_mesh("tests/data/00190663.obj")
@@ -87,6 +100,7 @@ def test_generate():
     assert atlas.chart_count == 70
     assert atlas.width == 1057
     assert atlas.height == 1057
+
 
 def test_get_mesh():
     mesh = trimesh.load_mesh("tests/data/00190663.obj")

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -98,8 +98,8 @@ def test_generate():
     assert uvs.shape == (18996, 2)
 
     assert atlas.chart_count == 70
-    assert atlas.width >= 1057
-    assert atlas.height >= 1057
+    assert atlas.width >= 900
+    assert atlas.height >= 900
 
 
 def test_get_mesh():

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -77,7 +77,7 @@ def test_add_mesh():
 
 
 def test_generate():
-    mesh = trimesh.load_mesh("tests/data/00190663.obj")
+    mesh = trimesh.load_mesh(os.path.join(cwd, "data", "00190663.obj"))
 
     atlas = xatlas.Atlas()
     atlas.add_mesh(mesh.vertices, mesh.faces, mesh.vertex_normals)

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -98,8 +98,8 @@ def test_generate():
     assert uvs.shape == (18996, 2)
 
     assert atlas.chart_count == 70
-    assert atlas.width == 1057
-    assert atlas.height == 1057
+    assert atlas.width >= 1057
+    assert atlas.height >= 1057
 
 
 def test_get_mesh():

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -103,7 +103,7 @@ def test_generate():
 
 
 def test_get_mesh():
-    mesh = trimesh.load_mesh("tests/data/00190663.obj")
+    mesh = trimesh.load_mesh(os.path.join(cwd, "data", "00190663.obj"))
 
     atlas = xatlas.Atlas()
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,11 +1,17 @@
-import pytest
+import os
 import trimesh
 import xatlas
 
-def test_parametrize():
-    mesh = trimesh.load_mesh("tests/data/00190663.obj")
+# current working directory
+cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
 
-    vmapping, indices, uvs = xatlas.parametrize(mesh.vertices, mesh.faces, mesh.vertex_normals)
+
+def test_parametrize():
+    mesh = trimesh.load_mesh(os.path.join(cwd, "data", "00190663.obj"))
+
+    vmapping, indices, uvs = xatlas.parametrize(
+        mesh.vertices, mesh.faces, mesh.vertex_normals
+    )
     assert vmapping.shape == (18996,)
     assert indices.shape == (32668, 3)
     assert uvs.shape == (18996, 2)


### PR DESCRIPTION
Thanks for maintaining these bindings! I went down a slight rabbit hole trying to get Python 3.12 wheels built:

- updates `cibuildwheel` version to build wheels for 3.7-3.12
  - dropped 3.6 as it needs special handling (for TOML) and also has been unsupported since 2021
- moves most project info from `setup.py` to `pyproject.toml`
- adds `test` extra, i.e. `pip install xatlas[test]`
  - `cibuildwheel` installs this extra and runs tests on every wheel
- adds `numpy` as a dependency to fix import on a pip install
- updates `extern/xatlas` to the latest upstream commit. It doesn't look like there's been much changed.
- updated tests
   - now uses file relative paths for loading models so they can be run from any working directory.
   - returned width and height appear to not be totally deterministic or set explicitly (i.e. 1067 on x64, 996 on i686, old test was `== 1057`) so I just set the check to be `>= 900`. 
   - on some platforms these tests are very very slow (220s) which on investigation is actually the test command compiling numpy. I left everything that succeeded even if it was making the matrix slow. The actual tests run very quickly. 

This is currently building [all wheels successfully](https://github.com/mikedh/xatlas-python/actions/runs/7733054867).