### PR TITLE
Support using system CMake and Ninja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "ninja; sys_platform != 'win32'",
-    "cmake>=3.12",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 # -*- coding: utf-8 -*-
 import os
+import shutil
 import sys
 import subprocess
 
@@ -100,9 +101,17 @@ class CMakeBuild(build_ext):
         )
 
 
+setup_requires = []
+if shutil.which("cmake") is None:
+    setup_requires += ["cmake>=3.12"]
+if shutil.which("ninja") is None:
+    setup_requires += ["ninja; sys_platform != 'win32'"]
+
+
 # The information here can also be placed in pyproject.toml - better separation of
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     ext_modules=[CMakeExtension("xatlas")],
+    setup_requires=setup_requires,
     cmdclass={"build_ext": CMakeBuild},
 )


### PR DESCRIPTION
Add `cmake` and `ninja` PyPI dependencies only if the respective programs are not found, and use system tools instead.  This avoids unnecessary dependencies on third-party binary packages, and improves portability by using downstream-patched CMake version.