### PR TITLE
Update pybind11 to fix build

### DIFF
--- a/.github/workflows/install-and-test.yml
+++ b/.github/workflows/install-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.23.2
         with:
           output-dir: wheelhouse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ content-type = "text/markdown"
 
 [project.optional-dependencies]
 test = ["trimesh",
-        "pytest"]
+        "pytest",
+        "scipy"]
 
 [tool.cibuildwheel]
 # Run the package tests on every wheel using `pytest`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xatlas"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 version = "0.0.9"
 authors = [{name = "Markus Worchel", email = "m.worchel@campus.tu-berlin.de"}]
 license = {file = "LICENSE"}

--- a/setup.py
+++ b/setup.py
@@ -93,10 +93,10 @@ class CMakeBuild(build_ext):
             os.makedirs(self.build_temp)
 
         subprocess.check_call(
-            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, stderr=subprocess.STDOUT
         )
         subprocess.check_call(
-            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+            ["cmake", "--build", "."] + build_args, cwd=self.build_temp, stderr=subprocess.STDOUT
         )
 
 


### PR DESCRIPTION
For some reason builds of xatlas started failing today (https://github.com/mikedh/trimesh/issues/2382). I think they finally deprecated something in Cmake somewhere, but updating to the latest `pybind11` appears to have fixed it for me locally.

This PR also updates CIBW which should build wheels for Python 3.13 