### PR TITLE
Vertex assignments and chart array access

### DIFF
--- a/src/atlas.cpp
+++ b/src/atlas.cpp
@@ -176,6 +176,29 @@ MeshResult Atlas::getMesh(std::uint32_t index) const
     return std::make_tuple(mapping, indices, uvs);
 }
 
+VertexAssignment Atlas::getMeshVertexAssignment(std::uint32_t meshIndex) const
+{
+    if (meshIndex >= m_atlas->meshCount)
+    {
+        throw std::out_of_range("Mesh index " + std::to_string(meshIndex) + " out of bounds for atlas with " + std::to_string(m_atlas->meshCount) + " meshes.");
+    }
+
+    auto const& mesh = m_atlas->meshes[meshIndex];
+
+    py::array_t<std::uint32_t> atlasIndex(py::array::ShapeContainer{mesh.vertexCount});
+    py::array_t<std::uint32_t> chartIndex(py::array::ShapeContainer{mesh.vertexCount});
+    auto atlasIndex_ = atlasIndex.mutable_unchecked<1>();
+    auto chartIndex_ = chartIndex.mutable_unchecked<1>();
+    for (size_t v = 0; v < static_cast<size_t>(mesh.vertexCount); ++v)
+    {
+        auto const& vertex = mesh.vertexArray[v];
+        atlasIndex_(v) = vertex.atlasIndex;
+        chartIndex_(v) = vertex.chartIndex;
+    }
+
+    return std::make_tuple(atlasIndex, chartIndex);
+}
+
 float Atlas::getUtilization(std::uint32_t index) const
 {
     if (index >= m_atlas->atlasCount)

--- a/src/atlas.hpp
+++ b/src/atlas.hpp
@@ -34,7 +34,16 @@
 #include <optional>
 #include <tuple>
 
-using MeshResult = std::tuple<pybind11::array_t<std::uint32_t>, pybind11::array_t<std::uint32_t>, pybind11::array_t<float>>;
+using MeshResult = std::tuple<
+    pybind11::array_t<std::uint32_t>, 
+    pybind11::array_t<std::uint32_t>, 
+    pybind11::array_t<float>
+>;
+
+using VertexAssignment = std::tuple<
+    pybind11::array_t<std::uint32_t>, // Atlas index
+    pybind11::array_t<std::uint32_t>  // Chart index
+>;
 
 class Atlas
 {
@@ -55,6 +64,8 @@ public:
     void generate(xatlas::ChartOptions const& chartOptions = xatlas::ChartOptions(), xatlas::PackOptions const& packOptions = xatlas::PackOptions(), bool verbose = false);
 
     MeshResult getMesh(std::uint32_t index) const;
+
+    VertexAssignment getMeshVertexAssignment(std::uint32_t meshIndex) const;
 
     float getUtilization(std::uint32_t index) const;
 

--- a/src/atlas.hpp
+++ b/src/atlas.hpp
@@ -45,6 +45,14 @@ using VertexAssignment = std::tuple<
     pybind11::array_t<std::uint32_t>  // Chart index
 >;
 
+struct Chart
+{
+    pybind11::array_t<std::uint32_t> faces;
+    uint32_t                         atlasIndex; // Sub-atlas index.
+    xatlas::ChartType                type;
+    uint32_t                         material;
+};
+
 class Atlas
 {
 public:
@@ -66,6 +74,10 @@ public:
     MeshResult getMesh(std::uint32_t index) const;
 
     VertexAssignment getMeshVertexAssignment(std::uint32_t meshIndex) const;
+
+    uint32_t getMeshChartCount(std::uint32_t meshIndex) const;
+
+    Chart getMeshChart(std::uint32_t meshIndex, std::uint32_t chartIndex) const;
 
     float getUtilization(std::uint32_t index) const;
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -139,7 +139,13 @@ void exportObj(std::string const&                            path,
 
 PYBIND11_MODULE(xatlas, m)
 {
-    // Bindings
+    py::enum_<xatlas::ChartType>(m, "ChartType")
+    .value("Planar", xatlas::ChartType::Planar)
+    .value("Ortho", xatlas::ChartType::Ortho)
+    .value("LSCM", xatlas::ChartType::LSCM)
+    .value("Piecewise", xatlas::ChartType::Piecewise)
+    .value("Invalid", xatlas::ChartType::Invalid);
+    
     ChartOptions::bind(m);
     PackOptions::bind(m);
     Atlas::bind(m);


### PR DESCRIPTION
This PR implements an API to access the assignment of mesh vertices to atlases and charts (fixes https://github.com/mworchel/xatlas-python/issues/8), and a mesh's chart array.